### PR TITLE
Create BaseTest.java

### DIFF
--- a/BaseTest.java
+++ b/BaseTest.java
@@ -1,0 +1,26 @@
+package com.janitri.qa.tests;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.testng.annotations.*;
+
+public class BaseTest {
+    protected WebDriver driver;
+
+    @BeforeClass
+    public void setup() {
+        // Set path to chromedriver executable if needed
+        // System.setProperty("webdriver.chrome.driver", "path/to/chromedriver");
+
+        driver = new ChromeDriver();
+        driver.manage().window().maximize();
+        driver.get("https://dev-dash.janitri.in/");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds the BaseTest.java class which is responsible for:

Initializing the Selenium WebDriver (ChromeDriver) before running tests

Maximizing the browser window and navigating to the Janitri Dashboard URL

Quitting the browser after all tests complete

This base class will be extended by other test classes to reuse the setup and teardown functionality, ensuring consistent test environment configuration.